### PR TITLE
Initialize counter value of redblacktree

### DIFF
--- a/cluscore/cco_redblacktree.c
+++ b/cluscore/cco_redblacktree.c
@@ -75,6 +75,7 @@ void cco_redblacktree_baseInitialize(cco_redblacktree *o)
 {
 	o->baseRelease = &cco_redblacktree_baseRelease;
 	o->redblacktreeRoot = &g_cco_redblacktree_node_nil;
+	o->count = 0;
 	return;
 }
 


### PR DESCRIPTION
cco_redblacktree_count() で要素をカウントした際に、時と場合によってまちまちな値が返ってくる問題を修正します。
counterの初期化がされていないのが原因と思われます。